### PR TITLE
更新_redirects文件，添加404页面返回状态码设置

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -4,3 +4,6 @@
 /control/:name/   /control/:name   301
 # 将 coco-community.pages.dev 的所有请求 301 重定向到 cc.zitzhen.cn，保留路径和参数
 https://coco-community.pages.dev/* https://cc.zitzhen.cn/:splat 301
+
+# 让404.html的页面返回 HTTP 404 而不是 200
+/* /404.html 404


### PR DESCRIPTION
# 修改`_redirects`文件使其修改HTTP代码
  经过测试`https://cc.zitzhen.cn/404`在Google搜索引擎上为软404，在bing上可以被索引，HTTP返回的是200而不是404，为了不影响SEO，我对`_redirects`文件进行了修改，使其访问`https://cc.zitzhen.cn/404`时，返回的HTTP代码是404而不是200。