### PR TITLE
更改Gitlab的链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ CoCo-Community，全称为ZIT-CoCo-Community
 
 [Github](https://github.com/zitzhen/CoCo-Community)  
 [Gitee](https://gitee.com/hello-oliver/CoCo-Community)  
-[Gitlab](https://gitlab.com/oliverxiaozhen/CoCo-Community)  
+[Gitlab（极狐）](https://jihulab.com/zitzhen/CoCo-Community)  
 >自2025年06月13日以来，Gitlab的访问已恢复。
 >
 > 若您发现未在此公布的平台出现仓库，请您即使举报并联系ZIT-CoCo-Community开发者名单


### PR DESCRIPTION
由于国际版Gitlab，无法使用仅限仓库，先更改为中国版“极狐”