### PR TITLE
更新_redirects文件，更换代码顺序

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -6,5 +6,5 @@
 https://coco-community.pages.dev/* https://cc.zitzhen.cn/:splat 301
 
 # 让404.html的页面返回 HTTP 404 而不是 200
-/* /404.html 404
 /404.html /404.html 404
+/* /404.html 404


### PR DESCRIPTION
# 更换原因：
 * 为了让访问`404.html`时返回HTTP404的人工智能建议。
 