### PR TITLE
修复错误按钮不能关闭错误弹窗的问题

### DIFF
--- a/user/js/script.js
+++ b/user/js/script.js
@@ -1,3 +1,7 @@
+function off_error_button(){
+    error_prompt_small_windows.style.display = 'none';
+}
+
 // 标签切换功能
 document.addEventListener('DOMContentLoaded', function() {
     const tabs = document.querySelectorAll('.tab');


### PR DESCRIPTION
# 修复错误按钮不能关闭错误弹窗的问题
## 更新日志：
* 使错误弹窗的取消按钮可以被按下