### PR TITLE
删除规则，防止冲突与覆盖

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -5,9 +5,6 @@
 # 将 coco-community.pages.dev 的所有请求 301 重定向到 cc.zitzhen.cn，保留路径和参数
 https://coco-community.pages.dev/* https://cc.zitzhen.cn/:splat 301
 
-# 让404.html的页面返回 HTTP 404 而不是 200
-/404.html /404.html 404
-/* /404.html 404
 
 ## 用户页面
 /user/?username=:username    /user/:username   301


### PR DESCRIPTION
# 删除规则
删除在`_redirects `的规则，防止与`_headers`进行冲突