### PR TITLE
优化404错误处理逻辑，增强对特殊路径的支持

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,23 +1,30 @@
 // functions/_middleware.js
 export async function onRequest({ request, next, env }) {
   const url = new URL(request.url);
+  
+  // 1. 先执行正常请求
   const response = await next();
   
-  // 处理直接访问 404.html 的情况
-  if (url.pathname === '/404.html') {
+  // 2. 处理特殊路径的404状态码覆盖
+  if (url.pathname === '/404' || url.pathname === '/404.html') {
     return new Response(response.body, {
       status: 404,
       headers: response.headers
     });
   }
   
-  // 处理不存在的路径
+  // 3. 处理实际不存在的路径（原始响应已是404的情况）
   if (response.status === 404) {
-    return new Response(
-      await env.ASSETS.fetch(new Request(url.origin + '/404.html')),
-      { status: 404, headers: response.headers }
+    const notFoundResponse = await env.ASSETS.fetch(
+      new Request(new URL('/404.html', url.origin))
     );
+    
+    return new Response(notFoundResponse.body, {
+      status: 404,
+      headers: notFoundResponse.headers
+    });
   }
   
+  // 4. 其他正常响应
   return response;
 }


### PR DESCRIPTION
# 优化404错误处理逻辑，增强对特殊路径的支持
## 解决问题：
访问`https://cc.zitzhen.cn/404.html`时HTTP才是`404`，访问`https://cc.zitzhen.cn`时HTTP代码为`200`