### PR TITLE
优化 GitHub Actions 工作流以生成和更新控制文件夹列表

### DIFF
--- a/.github/workflows/list.yml
+++ b/.github/workflows/list.yml
@@ -1,47 +1,62 @@
 name: Update control folder list
 
 on:
-  workflow_dispatch:   # 允许手动触发  
+  workflow_dispatch:  # 允许手动触发
   push:
+    branches: [main]  # 仅 main 分支推送时触发
+    paths: 
+      - 'control/**'  # 仅当 control/ 目录内容变化时触发
+  pull_request:
+    branches: [main]  # 仅 main 分支的 PR 合并时触发
+    types: [closed]   # 仅在 PR 关闭（合并）时运行
     paths:
-      - 'control/**' # 只有当control文件夹内容变化时触发
+      - 'control/**'  # 仅当 control/ 目录内容变化时触发
 
 jobs:
   generate-list:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0 # 获取完整历史记录以便创建分支
-    
-    - name: Generate list.json
-      id: generate
-      run: |
-        # 进入control目录并获取所有子文件夹（排除js和css）
-        cd control || exit 1
-        # 使用find命令获取所有目录，排除js和css，然后转换为相对路径
-        dirs=$(find . -mindepth 1 -maxdepth 1 -type d ! -name "js" ! -name "css" -printf '%P\n' | jq -R -s -c 'split("\n")[:-1]')
-        cd ..
-        
-        # 创建指定的JSON结构
-        echo "{\"list\": $dirs}" > list.json
-        
-        # 打印生成的JSON内容
-        cat list.json
-        
-        # 检查文件是否有变化
-        echo "has_changes=$(git diff --exit-code --quiet list.json || echo 'true')" >> $GITHUB_OUTPUT
-    
-    - name: Create Pull Request
-      if: steps.generate.outputs.has_changes == 'true'
-      uses: peter-evans/create-pull-request@v5
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: "Update list.json with latest control folders"
-        title: "Update control folder list"
-        body: "Automatically updated list of folders in control directory (excluding js and css)"
-        branch: "update-control-list-$(date +%s)" # 使用时间戳确保分支唯一
-        delete-branch: true
-        labels: "automated"
+      - name: Checkout repository (with full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # 获取完整 Git 历史记录
+
+      - name: Generate list.json
+        id: generate
+        run: |
+          # 进入 control 目录并获取所有子文件夹（排除 js 和 css）
+          cd control || exit 1
+          dirs=$(find . -mindepth 1 -maxdepth 1 -type d ! -name "js" ! -name "css" -printf '%P\n' | jq -R -s -c 'split("\n")[:-1]')
+          cd ..
+
+          # 生成新的 JSON 内容
+          new_json="{\"list\": $dirs}"
+          echo "$new_json" > list.json
+
+          # 检查是否与当前版本不同
+          if [ -f "list.json" ]; then
+            current_json=$(cat list.json)
+            if [ "$new_json" = "$current_json" ]; then
+              echo "No changes detected in list.json"
+              echo "has_changes=false" >> $GITHUB_OUTPUT
+              exit 0  # 无变化，直接退出
+            fi
+          fi
+
+          # 如果有变化，输出并暂存更改
+          echo "Changes detected in list.json"
+          git add list.json
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request (if changes detected)
+        if: steps.generate.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update list.json with latest control folders"
+          title: "Update control folder list"
+          body: "Automatically updated list of folders in control directory (excluding js and css)"
+          branch: "update-control-list-$(date +%s)"  # 唯一分支名
+          delete-branch: true  # PR 合并后删除分支
+          labels: "automated"


### PR DESCRIPTION
# 优化 GitHub Actions 工作流以生成和更新控制文件夹列表
1. 触发条件优化
push + pull_request
现在仅在 main 分支的 推送 或 PR 合并 时触发，且仅当 control/ 目录内容变化时才运行。

2. 精确检测 JSON 变化
直接比较 JSON 内容（而不是依赖 git diff）
避免因空格、换行符等无关变化误判，确保只有当 list.json 实际内容变化 时才创建 PR。

3. 无变化时静默退出
如果 list.json 无变化，工作流会直接结束，不创建 PR，减少冗余任务。

4. 分支唯一性保障
使用 $(date +%s) 生成唯一分支名，避免冲突。