### PR TITLE
优化 GitHub Actions 工作流，移除不必要的推送触发，简化控制文件夹列表生成逻辑

### DIFF
--- a/.github/workflows/list.yml
+++ b/.github/workflows/list.yml
@@ -2,15 +2,11 @@ name: Update control folder list
 
 on:
   workflow_dispatch:  # 允许手动触发
-  push:
-    branches: [main]  # 仅 main 分支推送时触发
-    paths: 
-      - 'control/**'  # 仅当 control/ 目录内容变化时触发
   pull_request:
-    branches: [main]  # 仅 main 分支的 PR 合并时触发
-    types: [closed]   # 仅在 PR 关闭（合并）时运行
+    branches: [main]  # 仅针对 main 分支的 PR
+    types: [closed]   # 仅在 PR 合并时触发（不是创建或更新时）
     paths:
-      - 'control/**'  # 仅当 control/ 目录内容变化时触发
+      - 'control/**'  # 仅当 PR 中包含 control/ 目录的变更
 
 jobs:
   generate-list:
@@ -21,11 +17,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # 获取完整 Git 历史记录
+          ref: ${{ github.event.pull_request.merge_commit_sha }}  # 关键！检出合并后的代码
 
       - name: Generate list.json
         id: generate
         run: |
-          # 进入 control 目录并获取所有子文件夹（排除 js 和 css）
+          # 进入 control 目录并获取子文件夹列表
           cd control || exit 1
           dirs=$(find . -mindepth 1 -maxdepth 1 -type d ! -name "js" ! -name "css" -printf '%P\n' | jq -R -s -c 'split("\n")[:-1]')
           cd ..
@@ -34,20 +31,16 @@ jobs:
           new_json="{\"list\": $dirs}"
           echo "$new_json" > list.json
 
-          # 检查是否与当前版本不同
-          if [ -f "list.json" ]; then
-            current_json=$(cat list.json)
-            if [ "$new_json" = "$current_json" ]; then
-              echo "No changes detected in list.json"
-              echo "has_changes=false" >> $GITHUB_OUTPUT
-              exit 0  # 无变化，直接退出
-            fi
+          # 检查是否与当前 main 分支的 list.json 不同
+          git show origin/main:list.json > old_list.json 2>/dev/null || echo "{}" > old_list.json
+          if diff -q old_list.json list.json; then
+            echo "No changes detected in list.json"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected in list.json"
+            git add list.json
+            echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
-
-          # 如果有变化，输出并暂存更改
-          echo "Changes detected in list.json"
-          git add list.json
-          echo "has_changes=true" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request (if changes detected)
         if: steps.generate.outputs.has_changes == 'true'
@@ -57,6 +50,6 @@ jobs:
           commit-message: "Update list.json with latest control folders"
           title: "Update control folder list"
           body: "Automatically updated list of folders in control directory (excluding js and css)"
-          branch: "update-control-list-$(date +%s)"  # 唯一分支名
-          delete-branch: true  # PR 合并后删除分支
+          branch: "update-control-list-$(date +%s)"
+          base: main  # 确保 PR 指向 main 分支
           labels: "automated"


### PR DESCRIPTION
关键改进说明
1. 精准触发条件
pull_request + types: [closed]
仅在 PR 合并到 main 分支 时触发（避免在 PR 创建或更新时重复运行）。

paths: 'control/**'
仅当合并的 PR 中包含 control/ 目录的变更时才运行。

2. 正确检出合并后的代码
ref: ${{ github.event.pull_request.merge_commit_sha }}
确保工作流检出的是 合并后的最新代码（而不是 PR 源分支的代码），否则 list.json 的比对会出错。

3. 精确比对文件变化
使用 git show origin/main:list.json 获取 main 分支当前的 list.json，与新生成的版本比对。
如果文件不存在（如首次运行），默认使用 {}。

4. 仅当有变化时创建 PR
通过 diff -q 静默比对文件内容，避免因空格/换行符等无关更改误判。