### PR TITLE
优化 GitHub Actions 工作流，新增生成唯一分支名称的步骤

### DIFF
--- a/.github/workflows/list.yml
+++ b/.github/workflows/list.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   generate-list:
-    # 确保只在PR成功合并时运行
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.merged }}
     runs-on: ubuntu-latest
 
@@ -19,37 +18,30 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # 安全处理不同触发场景
           ref: ${{ github.event.pull_request.merge_commit_sha || github.ref }}
 
       - name: Generate list.json
         id: generate
         run: |
-          # 确保control目录存在
           if [ ! -d "control" ]; then
             echo "Error: control directory not found!"
             exit 1
           fi
 
-          # 生成文件夹列表
           cd control
           dirs=$(find . -mindepth 1 -maxdepth 1 -type d \
             ! -name "js" ! -name "css" -printf '%P\n' | jq -R -s -c 'split("\n") | map(select(. != ""))')
           
-          # 创建JSON文件
           echo "{\"list\": $dirs}" > ../list.json
           cd ..
           
-          # 获取基础分支的list.json
           git fetch origin main:refs/remotes/origin/main
           if git show origin/main:list.json > old_list.json 2>/dev/null; then
             echo "Found existing list.json on main"
           else
             echo "{}" > old_list.json
-            echo "Created empty old_list.json"
           fi
           
-          # 检查差异
           if diff -q old_list.json list.json >/dev/null; then
             echo "No changes detected in list.json"
             echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -57,6 +49,16 @@ jobs:
             echo "Changes detected in list.json"
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
+
+      # 新增步骤：生成唯一分支名称
+      - name: Generate unique branch name
+        id: branch-name
+        if: steps.generate.outputs.has_changes == 'true'
+        run: |
+          timestamp=$(date +%s)
+          branch_name="update/control-list-$timestamp"
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+          echo "Generated branch name: $branch_name"
 
       - name: Create Pull Request (if changes detected)
         if: steps.generate.outputs.has_changes == 'true'
@@ -66,7 +68,7 @@ jobs:
           commit-message: "Update list.json with latest control folders"
           title: "Update control folder list"
           body: "Automatically updated list of folders in control directory (excluding js and css)"
-          branch: "update/control-list-$(date +%s)"  # 使用时间戳确保唯一性
+          branch: ${{ steps.branch-name.outputs.branch_name }}
           base: main
           delete-branch: true
           labels: "automated"


### PR DESCRIPTION
# 优化 GitHub Actions 工作流，新增生成唯一分支名称的步骤
## 关键修复：
### 新增分支名称生成步骤：

```yaml
- name: Generate unique branch name
  id: branch-name
  if: steps.generate.outputs.has_changes == 'true'
  run: |
    timestamp=$(date +%s)
    branch_name="update/control-list-$timestamp"
    echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
```
### 使用生成的合法分支名：

```yaml
branch: ${{ steps.branch-name.outputs.branch_name }}
```
### 确保分支名称有效性：

使用纯数字时间戳 `$(date +%s)` 避免特殊字符

保持 `update/ `前缀提高可读性

分支名称格式示例：`update/control-list-1718179200`