### PR TITLE
File协议警告

### DIFF
--- a/agreement/privacypolicy/index.html
+++ b/agreement/privacypolicy/index.html
@@ -31,3 +31,4 @@
 
 </body>
 <script src="../useragreement/js/script.js"></script>
+<script src="../../js/nofile.js"></script>

--- a/agreement/useragreement/index.html
+++ b/agreement/useragreement/index.html
@@ -31,3 +31,4 @@
 
 </body>
 <script src="js/script.js"></script>
+<script src="../../js/nofile.js"></script>

--- a/control/index.html
+++ b/control/index.html
@@ -187,4 +187,5 @@
 
 </body>
 <script src="js/script.js"></script>
+<script src="../js/nofile.js"></script>
 </html>

--- a/js/nofile.js
+++ b/js/nofile.js
@@ -1,0 +1,21 @@
+// 检测是否使用 file:// 协议
+if (window.location.protocol === 'file:') {
+    // 创建警告框
+    const warning = document.createElement('div');
+    warning.style.position = 'fixed';
+    warning.style.top = '0';
+    warning.style.left = '0';
+    warning.style.right = '0';
+    warning.style.backgroundColor = '#ff4444';
+    warning.style.color = 'white';
+    warning.style.padding = '10px';
+    warning.style.textAlign = 'center';
+    warning.style.fontFamily = 'Arial, sans-serif';
+    warning.style.fontWeight = 'bold';
+    warning.style.boxShadow = '0 2px 5px rgba(0, 0, 0, 0.3)';
+    warning.style.zIndex = '9999';
+    warning.textContent = '⚠️ 您正在使用 file:// 协议访问，可能出现问题，请使用 localhost 进行调试！';
+
+    // 添加到页面顶部
+    document.body.prepend(warning);
+}

--- a/user/index.html
+++ b/user/index.html
@@ -147,5 +147,6 @@
       
     <script src="js/script.js"></script>
     <script src="js/fetch.js"></script>
+    <script src="../js/nofile.js"></script>
 </body>
 </html>


### PR DESCRIPTION
# File协议警告
为了防止`file://`测试，增加这些代码。
## 常见问题
### 1. 为什么首页的`index.html`没有被引用
那是因为首页的`index.html`走的是GIthubAPI，没有涉及到`fetch()`到本地文件的内容，所以首页不需要增加警告。但后续为了减少GithubAPI使用量，所以可能需要`fetch()`本地文件，如果有，后续再说。