### PR TITLE
修复问题

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -2,9 +2,6 @@
 /control/?name=:name    /control/:name   301
 /control/:name    /control/?name=:name   200
 /control/:name/   /control/:name   301
-# 将 coco-community.pages.dev 的所有请求 301 重定向到 cc.zitzhen.cn，保留路径和参数
-https://coco-community.pages.dev/* https://cc.zitzhen.cn/:splat 301
-
 
 ## 用户页面
 /user/?username=:username    /user/:username   301

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -17,8 +17,11 @@ const routes = [
   { path: '/new-control', name:'new-control',component:() => import('@/views/essay/all/dev.vue') }
 ]
 
+// 在 Cloudflare Pages 环境中使用正确的 base
+const base = import.meta.env.BASE_URL || '/';
+
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(base),
   routes
 })
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,4 +27,6 @@ export default defineConfig({
         host: 'localhost',
         port: 5173,
       },
+  // 为 Cloudflare Pages 配置基础路径
+  base: process.env.NODE_ENV === 'production' ? './' : '/',
 })


### PR DESCRIPTION
# 修复内容
1. Vue Router 配置： - 为 Cloudflare Pages 环境添加了正确的 base 配置 - 使用 `import.meta.env.BASE_URL || '/'` 来动态设置路由基础路径。

2. 重定向配置： - 移除了会导致所有请求重定向到 cc.zitzhen.cn 的规则 - 保留了项目所需的其他重定向规则

3. Vite 配置：
- 添加了 base: process.env.NODE_ENV === 'production' ? './' : '/' 配置
- 确保在生产环境中使用相对路径，适配 C loudflare Pages

---
# Cloudflare Pages 部署建议：

   1. 构建设置：
      - 构建命令：npm run build
      - 构建输出目录：dist

   2. 测试部署：
      - 部署后测试所有页面路由是否正常工作
      - 检查重定向规则是否按预期工作