### PR TITLE
创建读取Github用户信息的API

### DIFF
--- a/functions/api/me.ts
+++ b/functions/api/me.ts
@@ -1,0 +1,55 @@
+export const onRequestGet: PagesFunction = async ({ request }) => {
+  try {
+    // 1. 解析 Cookie
+    const cookieHeader = request.headers.get("Cookie") || "";
+    const tokenMatch = cookieHeader.match(/(?:^|;\s*)token=([^;]+)/);
+    const token = tokenMatch ? decodeURIComponent(tokenMatch[1]) : null;
+
+    if (!token || token.length < 10) {
+      return new Response(JSON.stringify({ authenticated: false }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // 2. 请求 GitHub 用户信息
+    const githubRes = await fetch("https://api.github.com/user", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "User-Agent": "Cloudflare-Worker-OAuth",
+      },
+    });
+
+    if (!githubRes.ok) {
+      return new Response(JSON.stringify({ authenticated: false }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const user = await githubRes.json();
+
+    // 3. 返回精简用户信息
+    const safeUser = {
+      id: user.id,
+      login: user.login,
+      name: user.name,
+      avatar_url: user.avatar_url,
+      html_url: user.html_url,
+    };
+
+    return new Response(JSON.stringify({ authenticated: true, user: safeUser }), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (err: any) {
+    return new Response(JSON.stringify({ error: "server_error", message: err.message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};


### PR DESCRIPTION
- 从浏览器 Cookie 中读取 token（GitHub access token）
- 向 GitHub 请求用户信息，验证令牌是否有效
- 返回精简的用户信息（如头像、昵称、GitHub ID）
- 如果未登录或令牌无效，返回 401 或 { authenticated: false }
---
使用方法
```Javascript
const res = await fetch("/api/me", { credentials: "include" });
const data = await res.json();

if (data.authenticated) {
  console.log("已登录用户：", data.user);
} else {
  console.log("未登录");
}
```