### PR TITLE
「Gitlab同步Github Wiki」将推送模式更改为强制推送

### DIFF
--- a/.github/workflows/sync-to-gitlab-wiki.yml
+++ b/.github/workflows/sync-to-gitlab-wiki.yml
@@ -27,6 +27,6 @@ jobs:
           # 添加 GitLab Wiki 远程
           git remote add gitlab-wiki https://${GITLAB_USERNAME}:${GITLAB_TOKEN}@${GITLAB_URL}/${GITLAB_WIKI_REPO}.git
 
-          # 推送所有本地分支和标签到 Wiki
-          git push gitlab-wiki --all
-          git push gitlab-wiki --tags
+          # 推送所有本地分支和标签到 Wiki（强制推送）
+            git push gitlab-wiki --all --force
+            git push gitlab-wiki --tags --force


### PR DESCRIPTION
> [!WARNING]
> 将覆盖原有GitlabWiki
- 已确认可以覆盖 