### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/src/views/index.vue
+++ b/src/views/index.vue
@@ -194,7 +194,8 @@ export default {
     }
   },
   mounted() {
-    if (window.location.origin.includes("github.io")) {
+    const host = new URL(window.location.origin).hostname;
+    if (host === 'github.io' || host.endsWith('.github.io')) {
       document.getElementById("github_error").style.display = 'block';
     }
     this.getSubDirs();


### PR DESCRIPTION
Potential fix for [https://github.com/zitzhen/CoCo-Community/security/code-scanning/5](https://github.com/zitzhen/CoCo-Community/security/code-scanning/5)

To correctly detect if the site is hosted on a github.io domain, we must parse the hostname of the URL and check that the domain matches the expected github.io suffix appropriately. The best way to do this is by parsing `window.location.origin` into a URL object (using the standard `URL` class), extracting the `hostname`, and checking whether:
- The hostname ends with `.github.io`, or
- The hostname equals `github.io` (for the root domain, though normally github.io is only used as a suffix).

Since projects on github.io typically use a pattern like `<username>.github.io`, we should check if the hostname ends exactly with `.github.io`. We must avoid substring matching to eliminate false positives from hosts such as `fakegithub.io.com`, or `notgithub.io`.

Therefore, in `src/views/index.vue`, replace:
```js
if (window.location.origin.includes("github.io")) {
```
with:
```js
const host = new URL(window.location.origin).hostname;
if (host === 'github.io' || host.endsWith('.github.io')) {
```
No additional libraries are required, as the global `URL` class is available in modern browsers and Vue environments.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
