### PR TITLE
修复自动同步Gitee

### DIFF
--- a/.github/workflows/sync-to-gitee.yml
+++ b/.github/workflows/sync-to-gitee.yml
@@ -1,4 +1,6 @@
 name: Sync GitHub Repo and Wiki to Gitee
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
-  主仓库同步到 Gitee（排除 GitHub 的隐藏 refs，避免 remote rejected 错误）
- GitHub Wiki 仓库同步到 Gitee Wiki 仓库