### PR TITLE
使用Cloudflare中转GithubAPI

### DIFF
--- a/functions/api/github/user.ts
+++ b/functions/api/github/user.ts
@@ -4,8 +4,30 @@ export const onRequestGet: PagesFunction = async ({ request }) => {
   const origin = request.headers.get("Origin") || "";
   const referer = request.headers.get("Referer") || "";
   const allowedDomain = "https://cc.zitzhen.cn";
-
-  if (!origin.startsWith(allowedDomain) && !referer.startsWith(allowedDomain)) {
+  // Only allow if either Origin or Referer strictly equals the allowed domain as origin
+  const isValidOrigin = (() => {
+    try {
+      if (origin) {
+        const originUrl = new URL(origin);
+        if (originUrl.origin === allowedDomain) return true;
+      }
+    } catch (e) {
+      // Ignore parsing errors; treat as invalid
+    }
+    return false;
+  })();
+  const isValidReferer = (() => {
+    try {
+      if (referer) {
+        const refererUrl = new URL(referer);
+        if (refererUrl.origin === allowedDomain) return true;
+      }
+    } catch (e) {
+      // Ignore parsing errors; treat as invalid
+    }
+    return false;
+  })();
+  if (!isValidOrigin && !isValidReferer) {
     return new Response(JSON.stringify({ error: "Forbidden: Invalid origin" }), {
       status: 403,
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
使用Cloudflare边缘云函数中转用户的GithubAPI请求
> [!IMPORTANT]
> 此PR中的中转请求只是新增中转API，不代表已替换前端请求的API 