### PR TITLE
修复无法使用认证API的问题

### DIFF
--- a/src/views/control/index.vue
+++ b/src/views/control/index.vue
@@ -181,7 +181,7 @@ async function fetchData() {
         
         if (loginStatus && loginStatus.authenticated) {
           // 已登录，使用内部API
-          creatorRes = await fetch(`/api/github/users/${jsonData.author}`);
+          creatorRes = await fetch(`/api/github/user/?username=${jsonData.author}`);
         } else {
           // 未登录，使用GitHub API
           creatorRes = await fetch(`https://api.github.com/users/${jsonData.author}`);

--- a/src/views/user/index.vue
+++ b/src/views/user/index.vue
@@ -262,7 +262,7 @@ async function fetch_github_information(username) {
   
   if (loginStatus && loginStatus.authenticated) {
     // 已登录，使用内部API
-    url = `/api/github/users/${username}`;
+    url = `/api/github/user/?username=${jsonData.author}`;
   } else {
     // 未登录，使用GitHub API
     url = `https://api.github.com/users/${username}`;


### PR DESCRIPTION
修复日志
- 修复API名称的拼写错误，将users修改为user
- 修复传值方式，修正为正确的URL参数提交，而不是路径提交
> [!WARNING]
> 由于涉及登录，在这里还是没有办法本地测试，只能先提交在云测试看效果。  
> 这可能仍然存在问题