### PR TITLE
更新/user与/control的访问后的标题

### DIFF
--- a/src/views/user/No-parameters.vue
+++ b/src/views/user/No-parameters.vue
@@ -110,3 +110,15 @@ export default {
   }
 };
 </script>
+
+<script setup>
+import { useHead } from '@vueuse/head'
+
+useHead({
+  title: '请勿使用根路径访问|CoCo-Community',
+  meta: [{
+    name: 'robots',
+    content: 'noindex, nofollow',
+  }]
+})
+</script>


### PR DESCRIPTION
实现访问`/user`与`/control`页面时，标题自动更新为`请勿使用根路径访问|CoCo-Community`。
此外我们加了禁止爬虫爬取的HTML元标记