### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/list.yml
+++ b/.github/workflows/list.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   generate-list:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.merged }}
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/zitzhen/CoCo-Community/security/code-scanning/3](https://github.com/zitzhen/CoCo-Community/security/code-scanning/3)

To fix the problem, add a `permissions` block either at the workflow or job level in `.github/workflows/list.yml`. The permissions should be set to the least privilege required for all actions in the relevant job(s). For this workflow:

- Most steps perform read-only operations except when creating a pull request. 
- The `peter-evans/create-pull-request` action requires `contents: write` (to push changes/create branches) and `pull-requests: write` (to create PRs).

Specify these permissions at the job level, which ensures that only the specific job is granted the required permissions. Place the `permissions` section under the relevant job, above `runs-on` on line 14.

No new imports, definitions, or dependencies are needed; only the YAML block must be added.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
