### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync-to-gitlab-wiki.yml
+++ b/.github/workflows/sync-to-gitlab-wiki.yml
@@ -1,5 +1,8 @@
 name: Sync GitHub Wiki to GitLab Wiki
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/zitzhen/CoCo-Community/security/code-scanning/1](https://github.com/zitzhen/CoCo-Community/security/code-scanning/1)

To fix the issue, add a `permissions` key at either the root or job level in `.github/workflows/sync-to-gitlab-wiki.yml` to restrict GitHub Actions token permissions to the minimum necessary. Since there is no indication in this snippet that the workflow needs to write to the repo (all writes are performed via a personal GitLab token), specifying `contents: read` is minimally sufficient.  
**How to fix:**  
- Add `permissions: contents: read` at the root level (before `jobs:`), which will apply to all jobs not specifying their own permissions.
- No changes to imports or other areas are necessary.

**Where to change:**  
- Insert the block after the `name:` declaration and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
