### PR TITLE
修复安全漏洞

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5251,7 +5251,7 @@
         "@prerenderer/renderer-puppeteer": "^0.2.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.3",
-        "html-minifier": "^3.5.16",
+        "html-minifier": "^6.1.0",
         "mkdirp": "^1.0.4"
       },
       "peerDependencies": {


### PR DESCRIPTION
由于 reCustomIgnore 正则表达式在 html-minifier 4.0.0 中存在 灾难性回溯，攻击者可构造特定输入导致服务资源耗尽，从而造成拒绝服务