### PR TITLE
修复用户显示

### DIFF
--- a/src/views/user/list.vue
+++ b/src/views/user/list.vue
@@ -61,7 +61,6 @@ export default {
     }
   },
   mounted() {
-    this.updateLoginInfo();
     this.fetchuserlist();
   }
 };


### PR DESCRIPTION
- 删除多余的函数调用
# 问题调查——无法正确显示用户列表
在我们的`list.vue`代码中，由于上次导航栏改革，每个vue不再单独处理登录状态，由导航栏组建处理。但是在`list.vue`中，未删除`this.updateLoginInfo();`函数，控制台报错未捕捉的错误，导致无法继续运行后续的`this.fetchuserlist();`函数，线程中止。无法正常显示用户，现在已通过移除`this.updateLoginInfo();`函数修复此问题