### PR TITLE
feat(router): 添加页面访问记录请求

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -33,6 +33,12 @@ const router = createRouter({
   history: createWebHistory(base),
   routes,
   scrollBehavior(to, from, savedPosition) {
+  //发送记录请求
+  const domain = window.location.hostname;
+  if (!domain.includes("test") && !domain.includes("127.0.0.1") && !domain.includes("localhost")){
+    const apiUrl = `https://cc.zitzhen.cn/api/log?url=${window.location.href}`;
+    fetch(apiUrl, { method: 'GET' });
+  }
     // 始终滚动到顶部
     return { top: 0 }
   }


### PR DESCRIPTION
- 在路由的 `scrollBehavior` 方法中添加了对页面访问记录的请求。具体来说，在每次路由跳转时，会检查当前域名是否包含 "test"、"127.0.0.1" 或 "localhost"，如果不包含，则向指定的API发送GET请求，请求中包含了当前页面的URL信息。