### PR TITLE
移除所有updateLoginInfo()函数调用

### DIFF
--- a/src/views/essay/essay.vue
+++ b/src/views/essay/essay.vue
@@ -94,7 +94,6 @@ export default {
     }
   },
   mounted() {
-    this.updateLoginInfo();
     // 获取文章详情
     this.fetchArticleDetail();
   }

--- a/src/views/essay/index.vue
+++ b/src/views/essay/index.vue
@@ -68,7 +68,6 @@ export default {
     }
   },
   mounted() {
-    this.updateLoginInfo();
     this.fetchEssaylist();
   }
 };

--- a/src/views/issues/detail.vue
+++ b/src/views/issues/detail.vue
@@ -168,9 +168,7 @@ export default {
       return comment.body ? marked.parse(comment.body) : '';
     }
   },
-  async mounted() {
-    await this.updateLoginInfo();
-    
+  async mounted() {    
     const issueNumber = this.$route.params.number;
     if (issueNumber) {
       this.issue = await fetchIssueDetails(issueNumber, this.loginstatus);

--- a/src/views/issues/index.vue
+++ b/src/views/issues/index.vue
@@ -275,7 +275,6 @@ export default {
     },
   },
   async mounted() {
-    await this.updateLoginInfo();
     this.issues = await fetch_github_issues(this.loginstatus);
     this.filteredIssues = [...this.issues];
     this.extractUniqueLabels();

--- a/src/views/search/index.vue
+++ b/src/views/search/index.vue
@@ -302,9 +302,7 @@ export default {
       this.performSearch();
     }
   },
-  mounted() {
-    this.updateLoginInfo();
-    
+  mounted() {  
     // 如果URL中有搜索参数，执行搜索
     const query = this.$route.query.q;
     if (query) {

--- a/src/views/user/No-parameters.vue
+++ b/src/views/user/No-parameters.vue
@@ -66,15 +66,7 @@
 }
 </style>
 
-<script>
-import axios from 'axios';
 
-export default {
-  mounted() {
-    this.updateLoginInfo(); // 页面加载时调用
-  }
-};
-</script>
 
 <script setup>
 import { useHead } from '@vueuse/head'


### PR DESCRIPTION
自将导航栏模块化后`updateLoginInfo()`函数的调用未及时移除影响了很多模块的工作，以下是受影响的页面
## 受影响的页面
### 关于文章
- `essay.vue`文章查看
- `essay/index.vue`文章列表
### 关于Issues
- `detail.vue`Issues查看
- `issues/index.vue`Issues列表
### 关于搜索
- `search/index.vue`搜索功能
### 关于警告
- `No-parameters.vue`根访问警告
## 造成原因
在将导航栏模块后，未将`updateLoginInfo()`函数移除，报错`updateLoginInfo()`不是函数。未捕捉的错误导致主进程堵塞。