### PR TITLE
修复跳转URL错误的问题

### DIFF
--- a/src/views/essay/index.vue
+++ b/src/views/essay/index.vue
@@ -38,7 +38,7 @@
         </div>
 
         <div class="button-group">
-          <a :href="`/article/${encodeURIComponent(article.name)}`" class="text-btn">
+          <a :href="`/essay/${encodeURIComponent(article.id)}`" class="text-btn">
             <i class="fas fa-book-open"></i> 去详情页面
           </a>
         </div>


### PR DESCRIPTION
这应该也是一个多余的分支，应该又是压缩合并引起的Github未检测到的问题。
创建此PR的目的是为了安全的删除分支。